### PR TITLE
fix: stop disabling TLS verification as an SSL fallback

### DIFF
--- a/mp3_renamer.py
+++ b/mp3_renamer.py
@@ -315,12 +315,14 @@ def fix_ssl_certificate():
                     if result.returncode == 0:
                         print("SSL certificate installation successful")
                         return True
-            print("WARNING: Could not fix SSL certificates properly.")
-            print("As a temporary workaround, will disable SSL verification.")
-            print("This is NOT SECURE and should be fixed properly later.")
-            import ssl
-            ssl._create_default_https_context = ssl._create_unverified_context
-            return True
+            print("WARNING: Could not configure SSL certificates automatically.")
+            print("SSL verification will NOT be disabled, as that would expose")
+            print("downloads and API calls to man-in-the-middle attacks.")
+            print("To fix certificates, either:")
+            print("  1. Install certifi: pip install certifi")
+            print("  2. Run the 'Install Certificates.command' bundled with Python")
+            print("  3. Use --engine google to skip the Whisper model download")
+            return False
         except Exception as e:
             print(f"Error while trying to fix SSL certificates: {e}")
             print("Will attempt to continue but may encounter SSL errors")

--- a/run_mac_fix.py
+++ b/run_mac_fix.py
@@ -59,10 +59,11 @@ def fix_mac_ssl():
     
     if not found_script:
         print("Could not find certificate installation script.")
-        print("As a last resort, using SSL verification bypass (not secure)")
-        import ssl
-        ssl._create_default_https_context = ssl._create_unverified_context
-    
+        print("SSL verification will NOT be disabled, as that would expose")
+        print("downloads and API calls to man-in-the-middle attacks.")
+        print("Install certifi (pip install certifi) or run Python's")
+        print("'Install Certificates.command' to fix certificates instead.")
+
     return True
 
 def main():


### PR DESCRIPTION
## Problem

When the macOS certificate-install script couldn't be found, both `fix_ssl_certificate()` (`mp3_renamer.py`) and `fix_mac_ssl()` (`run_mac_fix.py`) fell back to **globally disabling TLS certificate verification** for the whole Python process:

```python
import ssl
ssl._create_default_https_context = ssl._create_unverified_context
```

This silently turned off MITM protection for everything the process does over HTTPS — the Whisper model download and the Google Speech API request — with no opt-in from the user. `mp3_renamer.py` even calls `fix_ssl_certificate()` automatically at startup (both at `__main__` and inside `main()`), so the bypass could engage without the user ever asking.

## Fix

Remove the `_create_unverified_context` bypass from both files. Instead print actionable guidance — install `certifi`, run Python's bundled `Install Certificates.command`, or use `--engine google` — and return `False` so callers surface the failure rather than proceeding insecurely. The existing secure `certifi`-based path is unchanged.

## Testing
- `python3 -m py_compile mp3_renamer.py run_mac_fix.py` passes.
- Confirmed no remaining references to `_create_unverified_context` in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ne8v7YQXyyG5Cg6cb3Wdcp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ne8v7YQXyyG5Cg6cb3Wdcp)_