### PR TITLE
refactor: remove dead code and fix placeholderless f-strings in mp3_renamer

### DIFF
--- a/mp3_renamer.py
+++ b/mp3_renamer.py
@@ -2,10 +2,8 @@
 MP3 Renamer - A tool to automatically rename MP3 files based on their speech content.
 """
 import os
-import sys
 import argparse
 import speech_recognition as sr
-import pydub
 from pathlib import Path
 from pydub import AudioSegment
 import re
@@ -227,7 +225,6 @@ def init_whisper_model(model_size="base"):
         return None
 
 def transcribe_with_whisper(audio_path, duration=10, start_time=0):
-    global WHISPER_MODEL
     if WHISPER_MODEL is None:
         print("Whisper model not initialized, attempting to load now...")
         init_whisper_model()


### PR DESCRIPTION
## Summary

Small, self-contained dead-code removal in `mp3_renamer.py`, found during a cross-repo scan with `pyflakes`. No behavior change.

## Changes

- **Drop unused imports** — `import sys` (never referenced) and the redundant bare `import pydub` (only `AudioSegment`, imported via `from pydub import AudioSegment`, is actually used).
- **Remove a no-op `global` declaration** — `transcribe_with_whisper` declared `global WHISPER_MODEL` but only *reads* the global, never assigns it, so the declaration did nothing. (`init_whisper_model`, which does assign it, keeps its `global`.)

These are all pure deletions of dead code.

## Testing

- `python -m py_compile mp3_renamer.py` → compiles cleanly

## Note

An earlier revision of this PR also stripped the `f` prefix from three placeholderless f-strings. Those cosmetic edits *modified* existing lines, which pulled pre-existing SonarCloud smells on those lines into the "New Code" maintainability rating and failed the Quality Gate. They've been dropped so this PR is purely deletions of genuinely unused code; the harmless f-string style nits can be handled separately.