### PR TITLE
fix(ci): repair corrupted python-app.yml workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,6 @@ jobs:
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: "3.10"
-        cache: 'pip'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     # PyAudio builds against PortAudio, which is not on the runner by default
     - name: Install PortAudio dependencies

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,14 +16,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Fix: Install system dependency needed for PyAudio
+    # PyAudio builds against PortAudio, which is not on the runner by default
     - name: Install PortAudio dependencies
       run: sudo apt-get update && sudo apt-get install -y portaudio19-dev
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
+        cache: 'pip'
 
     - name: Install dependencies
       run: |
@@ -38,5 +39,6 @@ jobs:
 
     - name: Test with pytest
       run: |
-](#)
-
+        # Exit code 5 means "no tests collected"; the repo has no test suite yet,
+        # so treat that as a pass rather than a failure.
+        pytest || [ $? -eq 5 ]

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,7 +21,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y portaudio19-dev
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: "3.10"
         cache: 'pip'


### PR DESCRIPTION
## Problem

The `Python application` workflow has failed to start on every push since 2026-07-21 (commit `f7c8d50`, "Update python-app.yml").

The file ends like this:

```yaml
    - name: Test with pytest
      run: |
](#)
```

A stray markdown link fragment `](#)` and a `U+2000` EN QUAD character were pasted onto the end of the file, and the `Test with pytest` step was left with an empty `run:` block. GitHub rejects the file at parse time, so the run is recorded as a startup failure with **zero jobs** — which is why the run shows as failed but has no job logs to inspect.

## Changes

- Remove the trailing `](#)` and the non-ASCII character
- Give the pytest step a real command. The repo has no test suite yet, so exit code 5 (`no tests collected`) is treated as a pass rather than a failure; a real suite will run normally once one is added
- Bump `actions/setup-python` v3 → v5
- Pin both `actions/checkout` and `actions/setup-python` to full commit SHAs, with the readable version kept in a trailing comment

## Verification

- The file parses as valid YAML (`yaml.safe_load`)
- No non-ASCII characters remain
- `flake8 . --count --select=E9,F63,F7,F82` — 0 issues, so the hard-fail lint gate passes
- The pytest step exits 0 against the current tree
- On CI, the `build` job now **runs and passes** — it could not start at all before this PR

`dependency-review` also improved from two unknown-license warnings to **"No vulnerabilities or license issues or OpenSSF Scorecard issues found"**, as a side effect of the SHA pinning.

## Known red check: SonarCloud

The `SonarCloud Code Analysis` gate fails on "C Security Rating on New Code". **This is pre-existing and not introduced by this PR** — the same check already fails on `main` at commit `9743501`. See [this comment](https://github.com/djleamen/renamer/pull/11#issuecomment-5198452145) for the full investigation and what was ruled out. Resolving it means changing the Python sources, not this workflow.

Every other check is green.

## Note

This repo has no tests. The workflow now passes rather than silently masking a gap, so adding a test suite for `mp3_renamer.py` is worth a follow-up.